### PR TITLE
feat: RawScript + tapmath for Inquisition opcodes

### DIFF
--- a/btcaaron/__init__.py
+++ b/btcaaron/__init__.py
@@ -27,7 +27,7 @@ from .legacy import (
 from .key import Key
 from .tree import TapTree, TaprootProgram, LeafDescriptor
 from .spend import SpendBuilder, Transaction
-from .script import Script
+from .script import Script, RawScript
 from .errors import (
     BtcAaronError,
     BuildError,
@@ -54,6 +54,7 @@ __all__ = [
     "SpendBuilder",
     "Transaction",
     "Script",
+    "RawScript",
     
     # Errors
     "BtcAaronError",

--- a/btcaaron/script/__init__.py
+++ b/btcaaron/script/__init__.py
@@ -2,6 +2,6 @@
 btcaaron.script - Script utilities
 """
 
-from .script import Script
+from .script import Script, RawScript
 
-__all__ = ["Script"]
+__all__ = ["Script", "RawScript"]

--- a/btcaaron/script/script.py
+++ b/btcaaron/script/script.py
@@ -66,3 +66,38 @@ class Script:
     
     def __repr__(self) -> str:
         return f"Script({self.to_asm()[:50]}...)"
+
+
+class RawScript:
+    """
+    Raw script wrapper that does NOT use bitcoin-utils parsing.
+    
+    Use for scripts containing non-standard opcodes (e.g. Inquisition 0x7e)
+    that bitcoin-utils would reject. Stores hex as-is without parsing.
+    
+    Example:
+        raw = RawScript("76a914" + pubkey_hash + "88ac")
+    """
+    
+    def __init__(self, hex_str: str):
+        """
+        Args:
+            hex_str: Script as hex string (no validation/parsing)
+        """
+        self._hex = hex_str
+        self._bytes = bytes.fromhex(hex_str)
+    
+    def to_hex(self) -> str:
+        """Get script as hex string."""
+        return self._hex
+    
+    def to_bytes(self) -> bytes:
+        """Get script as raw bytes."""
+        return self._bytes
+    
+    def to_asm(self) -> str:
+        """Simple display as hex (no parsing - use for RawScript)."""
+        return self._hex
+    
+    def __repr__(self) -> str:
+        return f"RawScript({self._hex[:32]}...)"

--- a/btcaaron/tree/builder.py
+++ b/btcaaron/tree/builder.py
@@ -4,7 +4,7 @@ btcaaron.tree.builder - TapTree Builder
 TapTree provides a fluent interface for constructing Taproot script trees.
 """
 
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, Union, TYPE_CHECKING
 import hashlib
 
 from ..key import Key
@@ -12,7 +12,7 @@ from .leaf import LeafDescriptor
 from .program import TaprootProgram
 
 if TYPE_CHECKING:
-    from ..script.script import Script
+    from ..script.script import Script, RawScript
 
 
 class TapTree:
@@ -174,7 +174,7 @@ class TapTree:
         })
         return self
     
-    def custom(self, script: "Script", *, label: str,
+    def custom(self, script: Union["Script", "RawScript"], *, label: str,
                unlock_hint: str = None) -> "TapTree":
         """
         Add a custom script leaf.
@@ -182,7 +182,7 @@ class TapTree:
         Unlock: .unlock_with([witness_element_1, ...])
         
         Args:
-            script: Script object
+            script: Script or RawScript (RawScript for non-standard opcodes e.g. Inquisition)
             label: Required - custom scripts must have a label
             unlock_hint: Description of how to unlock (for explain())
         """

--- a/btcaaron/tree/tapmath.py
+++ b/btcaaron/tree/tapmath.py
@@ -1,0 +1,132 @@
+"""
+btcaaron.tree.tapmath - Pure Taproot math (no bitcoin-utils)
+
+BIP 340/341 tagged hashes, tapleaf/tapbranch hashes, Merkle tree,
+and control block construction. Standard library only (hashlib, struct).
+"""
+
+import hashlib
+import struct
+from typing import List, Tuple
+
+# Tapscript leaf version per BIP 342
+LEAF_VERSION = 0xC0
+
+
+def tagged_hash(tag: str, data: bytes) -> bytes:
+    """
+    BIP 340 tagged hash: SHA256(SHA256(tag) || SHA256(tag) || data)
+    """
+    tag_digest = hashlib.sha256(tag.encode()).digest()
+    return hashlib.sha256(tag_digest + tag_digest + data).digest()
+
+
+def compact_size(n: int) -> bytes:
+    """
+    Bitcoin variable-length integer encoding.
+    """
+    if n < 0xFD:
+        return struct.pack("<B", n)
+    elif n <= 0xFFFF:
+        return struct.pack("<BH", 0xFD, n)
+    elif n <= 0xFFFFFFFF:
+        return struct.pack("<BI", 0xFE, n)
+    else:
+        return struct.pack("<BQ", 0xFF, n)
+
+
+def tapleaf_hash(script: bytes, leaf_version: int = LEAF_VERSION) -> bytes:
+    """
+    BIP 341 tapleaf hash: TaggedHash("TapLeaf", leaf_version || compact_size(len) || script)
+    """
+    payload = bytes([leaf_version]) + compact_size(len(script)) + script
+    return tagged_hash("TapLeaf", payload)
+
+
+def tapbranch_hash(left: bytes, right: bytes) -> bytes:
+    """
+    BIP 341 tapbranch hash. Inputs must be 32-byte hashes.
+    Hashes are combined in lexicographic order.
+    """
+    if len(left) != 32 or len(right) != 32:
+        raise ValueError("tapbranch_hash requires 32-byte inputs")
+    if left > right:
+        left, right = right, left
+    return tagged_hash("TapBranch", left + right)
+
+
+def compute_merkle_root(leaf_hashes: List[bytes]) -> bytes:
+    """
+    Build Taproot Merkle tree from leaf hashes.
+    Returns 32-byte merkle root (or single leaf's hash if only one).
+    """
+    if not leaf_hashes:
+        raise ValueError("Need at least one leaf")
+    for h in leaf_hashes:
+        if len(h) != 32:
+            raise ValueError(f"Leaf hash must be 32 bytes, got {len(h)}")
+
+    level = list(leaf_hashes)
+    while len(level) > 1:
+        next_level = []
+        for i in range(0, len(level), 2):
+            if i + 1 < len(level):
+                next_level.append(tapbranch_hash(level[i], level[i + 1]))
+            else:
+                next_level.append(level[i])
+        level = next_level
+    return level[0]
+
+
+def compute_merkle_proof(leaf_hashes: List[bytes], leaf_index: int) -> List[bytes]:
+    """
+    Compute Merkle proof (sibling path) for leaf at leaf_index.
+    Returns list of 32-byte hashes from leaf to root.
+    """
+    if leaf_index < 0 or leaf_index >= len(leaf_hashes):
+        raise ValueError(f"leaf_index {leaf_index} out of range for {len(leaf_hashes)} leaves")
+
+    level = list(leaf_hashes)
+    proof = []
+
+    while len(level) > 1:
+        # Add sibling to proof (if we have one; odd-one-out has no sibling)
+        if leaf_index % 2 == 0:  # we're left child
+            sibling_idx = leaf_index + 1
+            if sibling_idx < len(level):
+                proof.append(level[sibling_idx])
+        else:  # we're right child
+            proof.append(level[leaf_index - 1])
+
+        # Build next level
+        next_level = []
+        for i in range(0, len(level), 2):
+            if i + 1 < len(level):
+                next_level.append(tapbranch_hash(level[i], level[i + 1]))
+            else:
+                next_level.append(level[i])
+        level = next_level
+        leaf_index = leaf_index // 2
+
+    return proof
+
+
+def compute_control_block(
+    internal_key_bytes: bytes,
+    leaf_hashes: List[bytes],
+    leaf_index: int,
+    is_odd: bool,
+    leaf_version: int = LEAF_VERSION,
+) -> bytes:
+    """
+    Build control block bytes for script path spend.
+    internal_key_bytes: 32-byte x-only pubkey
+    leaf_hashes: list of tapleaf hashes (same order as tree)
+    leaf_index: which leaf is being spent
+    is_odd: output key Y parity (1 if odd, 0 if even)
+    """
+    if len(internal_key_bytes) != 32:
+        raise ValueError("internal_key must be 32 bytes")
+    proof = compute_merkle_proof(leaf_hashes, leaf_index)
+    version_byte = (leaf_version & 0xFE) | (1 if is_odd else 0)
+    return bytes([version_byte]) + internal_key_bytes + b"".join(proof)

--- a/tests/test_btcaaron_v01_cpfp.py
+++ b/tests/test_btcaaron_v01_cpfp.py
@@ -2,6 +2,7 @@
 """
 btcaaron - Simple Test Examples (Refactored)
 """
+import pytest
 from btcaaron import WIFKey, wif_to_addresses, quick_transfer
 
 WIF = "cPeon9fBsW2BxwJTALj3hGzh9vm8C52Uqsce7MzXGS1iFJkPF4AT"
@@ -31,10 +32,9 @@ def test_address_generation():
             print(f"  {typ:8}: {addr_obj.address}")
 
         print("✅ Address generation test passed!")
-        return True
     except Exception as e:
         print(f"❌ Address generation test failed: {e}")
-        return False
+        raise
 
 def test_utxo_scanning():
     print("\n" + "=" * 50)
@@ -52,10 +52,9 @@ def test_utxo_scanning():
                 print(f"    ... and {len(utxos) - 3} more")
 
         print("\n✅ UTXO scanning test completed!")
-        return True
     except Exception as e:
         print(f"❌ UTXO scanning test failed: {e}")
-        return False
+        raise
 
 def test_balance_check():
     print("\n" + "=" * 50)
@@ -75,11 +74,11 @@ def test_balance_check():
             print(f"\nHighest balance: {typ} | {bal:,} sats | {addr}")
 
         print("\n✅ Balance check test completed!")
-        return True
     except Exception as e:
         print(f"❌ Balance check test failed: {e}")
-        return False
+        raise
 
+@pytest.mark.skip(reason="Interactive - requires user input for real transfer")
 def test_transfer():
     print("\n" + "=" * 50)
     print("TEST 4: Transfer Transaction")
@@ -89,22 +88,22 @@ def test_transfer():
         candidates = [(t, a, a.get_balance()) for t, a in get_addresses(WIF).items() if a.get_balance() >= AMOUNT + FEE]
         if not candidates:
             print("❌ No address has sufficient balance.")
-            return False
+            raise AssertionError("No address has sufficient balance")
 
         from_type, from_addr, bal = sorted(candidates, key=lambda x: x[2], reverse=True)[0]
         print(f"From: {from_addr.address} ({from_type}, {bal:,} sats)")
         print(f"To:   {RECIPIENT} | Amount: {AMOUNT} | Fee: {FEE}")
         if input("Proceed? (y/N): ").lower() != 'y':
             print("Cancelled")
-            return False
+            raise AssertionError("User cancelled")
 
         txid = from_addr.send(RECIPIENT, AMOUNT, fee=FEE, debug=True).broadcast()
         print("✅ Broadcast TXID:", txid)
-        return True
     except Exception as e:
         print(f"❌ Transfer test failed: {e}")
-        return False
+        raise
 
+@pytest.mark.skip(reason="Interactive - requires user input for real transfer")
 def test_quick_transfer():
     print("\n" + "=" * 50)
     print("TEST 5: Quick Transfer")
@@ -117,18 +116,17 @@ def test_quick_transfer():
         print(f"Using {FROM}: {addr.address} | {bal:,} sats")
         if bal < AMOUNT + FEE:
             print("❌ Insufficient balance.")
-            return False
+            raise AssertionError("Insufficient balance")
 
         if input("Proceed? (y/N): ").lower() != 'y':
             print("Cancelled")
-            return False
+            raise AssertionError("User cancelled")
 
         txid = quick_transfer(WIF, FROM.lower(), RECIPIENT, AMOUNT, fee=FEE, debug=True)
         print("✅ Quick TXID:", txid)
-        return True
     except Exception as e:
         print(f"❌ Quick transfer test failed: {e}")
-        return False
+        raise
 
 def main():
     tests = [
@@ -159,5 +157,47 @@ def main():
     except Exception as e:
         print(f"❌ Error: {e}")
 
+@pytest.mark.skip(reason="Interactive - requires user input for real transfer")
+def test_cpfp():
+    print("\n" + "=" * 50)
+    print("TEST 6: CPFP Accelerator")
+    print("=" * 50)
+
+    # 父交易信息
+    PARENT_TXID = "5534b524df6d96822036ce4dc6037beb07cb536bd81a1dc822c19d5776615f1e"
+    PARENT_VOUT = 2
+    UTXO_AMOUNT = 47537  # sats
+    HIGH_FEE = 5000      # sats，直接给个高费吸引矿工
+    SEND_AMOUNT = UTXO_AMOUNT - HIGH_FEE
+
+    try:
+        addr = get_addresses(WIF)["Taproot"]
+        print(f"Spending parent UTXO: {PARENT_TXID}:{PARENT_VOUT}")
+        print(f"From address: {addr.address}")
+        print(f"To: {RECIPIENT} | Amount: {SEND_AMOUNT} sats | Fee: {HIGH_FEE} sats")
+
+        if SEND_AMOUNT <= 0:
+            print("❌ Fee too high, nothing left to send.")
+            raise AssertionError("Fee too high")
+
+        if input("Proceed with CPFP? (y/N): ").lower() != 'y':
+            print("Cancelled")
+            raise AssertionError("User cancelled")
+
+        # 手动指定UTXO来构建交易
+        tx = addr.send(
+            RECIPIENT,
+            SEND_AMOUNT,
+            fee=HIGH_FEE,
+            utxos=[{"txid": PARENT_TXID, "vout": PARENT_VOUT, "amount": UTXO_AMOUNT}],
+            debug=True
+        )
+        txid = tx.broadcast()
+        print("✅ CPFP TXID:", txid)
+    except Exception as e:
+        print(f"❌ CPFP test failed: {e}")
+        raise
+    
 if __name__ == "__main__":
     main()
+   

--- a/tests/test_rawscript_tapmath.py
+++ b/tests/test_rawscript_tapmath.py
@@ -1,0 +1,180 @@
+"""
+RawScript and tapmath unit tests
+
+Run with: pytest tests/test_rawscript_tapmath.py -v
+"""
+
+import pytest
+from btcaaron import Key, TapTree, RawScript
+
+
+# ============================================================================
+# RawScript Tests
+# ============================================================================
+
+class TestRawScript:
+    """Test RawScript class"""
+
+    def test_to_hex_roundtrip(self):
+        """RawScript hex round-trip"""
+        hex_str = "76a914" + "00" * 20 + "88ac"
+        raw = RawScript(hex_str)
+        assert raw.to_hex() == hex_str
+
+    def test_to_bytes_roundtrip(self):
+        """RawScript bytes round-trip"""
+        hex_str = "ac"  # OP_CHECKSIG
+        raw = RawScript(hex_str)
+        assert raw.to_bytes() == bytes.fromhex(hex_str)
+        assert raw.to_bytes().hex() == hex_str
+
+    def test_to_hex_to_bytes_consistency(self):
+        """to_hex and to_bytes must be consistent"""
+        hex_str = "76a91400112233445566778899aabbccddeeff0011223388ac"
+        raw = RawScript(hex_str)
+        assert raw.to_bytes().hex() == raw.to_hex()
+
+    def test_to_asm_returns_hex(self):
+        """to_asm returns hex or hex-like display (no parsing for RawScript)"""
+        raw = RawScript("ac")
+        asm = raw.to_asm()
+        assert "ac" in asm
+
+    def test_short_script(self):
+        """Single-byte script (OP_CHECKSIG)"""
+        raw = RawScript("ac")
+        assert raw.to_hex() == "ac"
+        assert raw.to_bytes() == b"\xac"
+        assert len(raw.to_bytes()) == 1
+
+
+# ============================================================================
+# tapmath Tests
+# ============================================================================
+
+class TestTapmath:
+    """Test tapmath module functions"""
+
+    def test_tapleaf_hash_length(self):
+        """tapleaf_hash returns 32 bytes"""
+        from btcaaron.tree.tapmath import tapleaf_hash
+        script = bytes.fromhex("ac")  # OP_CHECKSIG
+        h = tapleaf_hash(script)
+        assert len(h) == 32
+
+    def test_tapleaf_hash_deterministic(self):
+        """tapleaf_hash is deterministic"""
+        from btcaaron.tree.tapmath import tapleaf_hash
+        script = bytes.fromhex("76a914" + "00" * 20 + "88ac")
+        h1 = tapleaf_hash(script)
+        h2 = tapleaf_hash(script)
+        assert h1 == h2
+
+    def test_tapbranch_hash(self):
+        """tapbranch_hash combines two 32-byte hashes"""
+        from btcaaron.tree.tapmath import tapleaf_hash, tapbranch_hash
+        left = tapleaf_hash(b"\xac")
+        right = tapleaf_hash(b"\x00")
+        branch = tapbranch_hash(left, right)
+        assert len(branch) == 32
+        assert branch == tapbranch_hash(right, left)  # sorted order
+
+    def test_compute_merkle_root_single_leaf(self):
+        """Single leaf: merkle root = tapleaf_hash"""
+        from btcaaron.tree.tapmath import tapleaf_hash, compute_merkle_root
+        script = bytes.fromhex("ac")
+        leaf_hash = tapleaf_hash(script)
+        root = compute_merkle_root([leaf_hash])
+        assert root == leaf_hash
+
+    def test_compute_merkle_root_two_leaves(self):
+        """Two leaves: merkle root = tapbranch of both"""
+        from btcaaron.tree.tapmath import tapleaf_hash, tapbranch_hash, compute_merkle_root
+        h0 = tapleaf_hash(b"\xac")
+        h1 = tapleaf_hash(b"\x00")
+        root = compute_merkle_root([h0, h1])
+        expected = tapbranch_hash(h0, h1)
+        assert root == expected
+
+    def test_compute_merkle_proof_single_leaf(self):
+        """Single leaf: proof is empty (list or empty bytes)"""
+        from btcaaron.tree.tapmath import tapleaf_hash, compute_merkle_proof
+        h = tapleaf_hash(b"\xac")
+        proof = compute_merkle_proof([h], 0)
+        assert len(proof) == 0
+
+    def test_compute_merkle_proof_two_leaves(self):
+        """Two leaves: proof has one 32-byte sibling hash (list or concatenated bytes)"""
+        from btcaaron.tree.tapmath import tapleaf_hash, compute_merkle_proof
+        h0 = tapleaf_hash(b"\xac")
+        h1 = tapleaf_hash(b"\x00")
+        proof0 = compute_merkle_proof([h0, h1], 0)
+        proof1 = compute_merkle_proof([h0, h1], 1)
+        # proof: List[bytes] with 1 elem, or concatenated bytes (32 len)
+        sibling0 = proof0[0] if isinstance(proof0, list) else proof0
+        sibling1 = proof1[0] if isinstance(proof1, list) else proof1
+        assert len(sibling0) == 32
+        assert len(sibling1) == 32
+        assert sibling0 == h1
+        assert sibling1 == h0
+
+    def test_compute_control_block_format(self):
+        """control_block: version byte + 32 key + merkle proof"""
+        from btcaaron.tree.tapmath import tapleaf_hash, compute_control_block
+        internal_key = bytes.fromhex("00" * 32)
+        leaf_hashes = [tapleaf_hash(b"\xac"), tapleaf_hash(b"\x00")]
+        cb = compute_control_block(internal_key, leaf_hashes, 0, is_odd=False)
+        assert len(cb) == 65  # 1 + 32 + 32 (version + key + 1 proof element)
+        assert cb[0] in (0xc0, 0xc1)  # leaf version
+        assert cb[1:33] == internal_key
+
+
+# ============================================================================
+# RawScript + TapTree Integration
+# ============================================================================
+
+class TestRawScriptTapTree:
+    """RawScript with TapTree.custom() integration"""
+
+    @pytest.fixture
+    def keys(self):
+        return {
+            "alice": Key.from_wif("cRxebG1hY6vVgS9CSLNaEbEJaXkpZvc6nFeqqGT7v6gcW7MbzKNT"),
+            "bob": Key.from_wif("cSNdLFDf3wjx1rswNL2jKykbVkC6o56o5nYZi4FUkWKjFn2Q5DSG"),
+        }
+
+    def test_rawscript_single_leaf_address(self, keys):
+        """Single RawScript leaf produces valid tb1p address"""
+        # Simple OP_CHECKSIG script as RawScript (avoids bitcoinutils parsing)
+        raw = RawScript("ac")  # OP_CHECKSIG
+        program = (TapTree(internal_key=keys["alice"])
+            .custom(raw, label="raw")
+            .build())
+        assert program.address.startswith("tb1p")
+        assert len(program.address) == 62
+        assert program.num_leaves == 1
+        assert program.leaf("raw").script_type == "CUSTOM"
+
+    def test_rawscript_control_block(self, keys):
+        """RawScript leaf: control_block() returns valid hex"""
+        raw = RawScript("ac")
+        program = (TapTree(internal_key=keys["alice"])
+            .custom(raw, label="raw")
+            .build())
+        cb_hex = program.control_block("raw")
+        assert isinstance(cb_hex, str)
+        assert len(cb_hex) % 2 == 0
+        cb_bytes = bytes.fromhex(cb_hex)
+        assert cb_bytes[0] in (0xc0, 0xc1)
+        assert len(cb_bytes) == 33  # version + internal key (single leaf: no merkle proof)
+
+    def test_rawscript_merkle_root(self, keys):
+        """RawScript path sets merkle_root"""
+        raw = RawScript("ac")
+        program = (TapTree(internal_key=keys["alice"])
+            .custom(raw, label="raw")
+            .build())
+        mr = program.merkle_root
+        assert mr is not None
+        assert len(mr) == 64  # 32 bytes hex
+        assert all(c in "0123456789abcdef" for c in mr.lower())


### PR DESCRIPTION
- RawScript class for non-standard opcodes
- tapmath: tapleaf_hash, compute_merkle_root, compute_control_block
- builder.custom() accepts Script | RawScript
- program._compile() has_raw + tapmath path
- spend/builder uses program.control_block()
- Rename test v0.1 -> v01, add RawScript/tapmath tests