### PR TITLE
fix: reject duplicate leaf labels in TapTree.build()

### DIFF
--- a/btcaaron/tree/builder.py
+++ b/btcaaron/tree/builder.py
@@ -204,13 +204,28 @@ class TapTree:
     def build(self) -> TaprootProgram:
         """
         Freeze the tree and create a TaprootProgram.
-        
+
         After calling build(), the TapTree should not be modified
         (though this is not enforced).
-        
+
         Returns:
             TaprootProgram: Immutable program with address and spend methods
+
+        Raises:
+            BuildError: If duplicate leaf labels are detected
         """
+        from ..errors import BuildError
+
+        labels = [leaf["label"] for leaf in self._leaves]
+        seen = set()
+        dupes = []
+        for l in labels:
+            if l in seen:
+                dupes.append(l)
+            seen.add(l)
+        if dupes:
+            raise BuildError(f"Duplicate leaf labels: {dupes}")
+
         return TaprootProgram(
             internal_key=self._internal_key,
             leaves=self._leaves,

--- a/tests/test_btcaaron_v02.py
+++ b/tests/test_btcaaron_v02.py
@@ -682,6 +682,38 @@ class TestQuickTransferTaproot:
 
 
 # ============================================================================
+# Duplicate Label Rejection Tests
+# ============================================================================
+
+class TestDuplicateLabelRejection:
+    """Test that duplicate leaf labels are rejected at build time."""
+
+    @pytest.fixture
+    def keys(self):
+        return {
+            "alice": Key.from_wif(ALICE_WIF),
+            "bob": Key.from_wif(BOB_WIF),
+        }
+
+    def test_duplicate_labels_raise_build_error(self, keys):
+        """Duplicate labels should raise BuildError"""
+        from btcaaron.errors import BuildError
+        with pytest.raises(BuildError, match="Duplicate leaf labels"):
+            (TapTree(internal_key=keys["alice"])
+                .checksig(keys["bob"], label="same")
+                .checksig(keys["bob"], label="same")
+            ).build()
+
+    def test_unique_labels_work(self, keys):
+        """Unique labels should build fine"""
+        prog = (TapTree(internal_key=keys["alice"])
+            .checksig(keys["bob"], label="a")
+            .checksig(keys["bob"], label="b")
+        ).build()
+        assert prog.num_leaves == 2
+
+
+# ============================================================================
 # Run Tests
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- `TapTree.build()` now raises `BuildError` when duplicate leaf labels are detected
- Previously, duplicate labels silently overwrote earlier leaves in `_leaf_descriptors` (a `Dict[str, LeafDescriptor]`), causing data loss with no warning

## Reproduction

```python
prog = (TapTree(internal_key=alice)
    .checksig(bob, label="same")
    .checksig(bob, label="same")
).build()
print(prog.leaves)      # ['same'] — one leaf silently lost
print(prog.num_leaves)  # 1
```

## Changes

- **`builder.py`**: Added label uniqueness check in `build()` before passing leaves to `TaprootProgram`
- **`test_btcaaron_v02.py`**: Added 2 tests (`TestDuplicateLabelRejection`)

## Test plan

- [x] All 43 existing + new tests pass (`pytest tests/test_btcaaron_v02.py -v`)
- [x] All 68 tests pass (`pytest tests/ -v`, 63 passed, 5 skipped as expected)
- [x] No changes to existing behavior — only previously-silent errors now raise